### PR TITLE
fix: amend syntax on font cache header

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,8 +8,7 @@
     public,
     notransform,
     immutable,
-    max-age=31536000,
-    '''
+    max-age=31536000'''
 
 [[plugins]]
 package = "netlify-plugin-no-more-404"


### PR DESCRIPTION
Syntax was a bit off. This should set the cache header for Inter correctly.

## This PR

![Screenshot 2022-07-29 at 12 44 38](https://user-images.githubusercontent.com/41568/181751988-f4c1aaf6-977e-4958-b140-07e6121e80c1.png)

## Current prod

![Screenshot 2022-07-29 at 12 44 19](https://user-images.githubusercontent.com/41568/181751984-f5fa983f-a91f-4e6a-bc93-83b2ffe0851a.png)


