### PR TITLE
improve domain security

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,16 @@
 [[headers]]
   for = "/*"
   [headers.values]
+    Content-Security-Policy = """
+    frame-ancestors 'none';
+    base-uri 'none';
+    default-src 'self';
+    connect-src https://plausible.io;
+    img-src 'self';
+    object-src 'none';
+    script-src https://plausible.io/js/plausible.js;
+    style-src 'self' 'unsafe-inline';
+    """
     Referrer-Policy = "strict-origin-when-cross-origin"
     X-Content-Type-Options = "nosniff"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,11 @@
   publish = "src"
 
 [[headers]]
+  for = "/*"
+  [headers.values]
+    X-Content-Type-Options = "nosniff"
+
+[[headers]]
   for = "/Inter.var.woff2*"
   [headers.values]
     cache-control = '''

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
+    Referrer-Policy = "strict-origin-when-cross-origin"
     X-Content-Type-Options = "nosniff"
 
 [[headers]]


### PR DESCRIPTION
This does a few things to improve domain security:

- prevents ability to load scripts that have the incorrect mimetype
- sets a Referrer Policy to be the same as modern browser default, so really we're just being explicit
- adds a pretty locked-down Content Security Policy, with script exceptions for `https://plausible.io`

Here are reports from:

- [Mozilla Observatory](https://observatory.mozilla.org/analyze/deploy-preview-54--measuredco.netlify.app)
- [Security Headers](https://securityheaders.com/?followRedirects=on&hide=on&q=deploy-preview-54--measuredco.netlify.app)
- [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/):
    ![Screenshot 2023-03-09 at 11 43 46](https://user-images.githubusercontent.com/41568/224013329-0c396353-b60c-4bba-ad72-bd0b2ddbb04b.png)

