### PR TITLE
fix netlify lighthouse plugin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -55,11 +55,12 @@
 # https://github.com/netlify/netlify-plugin-lighthouse
 [[plugins]]
   package = "@netlify/plugin-lighthouse"
-  [plugins.inputs.thresholds]
-    performance = 0.9
-    accessibility = 0.9
-    best-practices = 0.9
-    seo = 0.9
-    pwa = 0.0 # We could bump this up if we support PWA in future
-  [plugins.inputs.audits]
+  [[plugins.inputs.audits]]
     output_path = "lighthouse/index.html"
+
+    [plugins.inputs.thresholds]
+      performance = 0.9
+      accessibility = 0.9
+      best-practices = 0.9
+      seo = 0.9
+      pwa = 0.0 # We could bump this up if we support PWA in future

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,6 +22,22 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     X-Content-Type-Options = "nosniff"
 
+# A special Content Security Policy for Lighthouse
+[[headers]]
+  for = "/lighthouse/*"
+  [headers.values]
+    Content-Security-Policy = """
+    frame-ancestors 'none';
+    base-uri 'none';
+    default-src 'self';
+    img-src data:;
+    object-src 'none';
+    script-src 'unsafe-inline';
+    style-src 'self' 'unsafe-inline';
+    """
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    X-Content-Type-Options = "nosniff"
+
 # Helps prevent some very noticeable FOUT on repeat visits
 [[headers]]
   for = "/Inter.var.woff2*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@netlify/plugin-lighthouse": "^4.0.3",
+    "@netlify/plugin-lighthouse": "^4.0.7",
     "@netlify/plugin-sitemap": "^0.8.1",
     "netlify-plugin-checklinks": "^4.1.1",
     "netlify-plugin-no-more-404": "^0.0.15"


### PR DESCRIPTION
The Netlify Lighthouse plugin either stopped generating the standalone Lighthouse HTML page or stopped including it in the build a few PRs back.

This bumps the plugin version (because why not), fixes the syntax for configuring the plugin in `netlify.toml` (it's inconsistent in the plugin docs) and adds a custom CSP for the Lighthouse report page (without which the report won't render).