### PR TITLE
build: ignore dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 
 # Local Netlify folder
 .netlify
+
+# Build
+dist


### PR DESCRIPTION
We ignore `dist` in our project branch, but not on `main` so the working copy gets polluted when switching back to `main` from project.
