### PR TITLE
build: add browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "postcss-import": "^15.1.0",
     "rimraf": "^5.0.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "browserslist": [
+    "defaults"
+  ]
 }


### PR DESCRIPTION
Just being explicit about [`defaults`](https://browsersl.ist/#q=defaults) for now.

Not using any additional `supports` queries just yet (e.g. the [`supports es6-module`](https://browsersl.ist/#q=supports+es6-module) one they use as boilerplate: doesn't seem worthwhile with current super minimal approach.

No need to set node support in browserslist just yet, but will do later anyway when bumping up everything from node v16 in anticipation of doing server rendering at some future point.