### PR TITLE
perf: disable next data revalidation and rely on page cache

### DIFF
--- a/app/api/puck/route.ts
+++ b/app/api/puck/route.ts
@@ -1,7 +1,6 @@
 import fs from "fs";
 import { supabase } from "../../../lib/supabase";
 
-import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { getUserServer } from "../../../lib/get-user-server";
 
@@ -45,9 +44,6 @@ export async function POST(request: Request) {
     const res = await supabase.from("puck").upsert(newData);
 
     if (res.status === 201) {
-      // Purge Next.js supabase cache
-      revalidateTag(path);
-
       return NextResponse.json({ status: "ok", data: newData });
     }
 
@@ -68,9 +64,6 @@ export async function POST(request: Request) {
     const res = await supabase.from("puck").insert(newData);
 
     if (res.status === 201) {
-      // Purge Next.js supabase cache
-      revalidateTag(path);
-
       return NextResponse.json({ status: "ok", data: newData });
     }
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -9,18 +9,7 @@ export const supabase = createClient(supabaseUrl, supabaseKey, {
   },
   global: {
     fetch: async (url, options) => {
-      const database = url.toString().split("v1/")[1].split("?")[0];
-
-      const tags = [];
-
-      if (database === "puck" && options.method === "GET") {
-        const params = new URLSearchParams(url.toString().split("?")[1]);
-        const path = params.get("path").replace("eq.", "");
-
-        tags.push(path);
-      }
-
-      return fetch(url, { ...options, next: { tags } });
+      return fetch(url, { ...options, next: { revalidate: 0 } });
     },
   },
 });


### PR DESCRIPTION
Let's try disabling Next's data revalidation and relying on the statically built pages to resolve the recent homepage reset.

We should check behaviour on the preview branch before merging.