### PR TITLE
feat: block ai crawlers

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,18 @@
 
 User-agent: *
 Disallow: /lighthouse/
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /


### PR DESCRIPTION
Built using info from https://originality.ai/ai-bot-blocking

Why? Because I can't see any advantage in having our content (scanty as it may be right now) used for training.

Note deliberately _not_ blocking `ChatGPT-User` because that feels like a useful use-case that explicitly doesn't allow training.