### PR TITLE
Add blog feeds

### DIFF
--- a/app/api/feed/atom/route.ts
+++ b/app/api/feed/atom/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import { generateFeed } from "../../../../lib/generate-feed";
+
+export const revalidate = 86400;
+
+export async function GET() {
+  const feed = await generateFeed();
+
+  return new NextResponse(feed.atom1(), {
+    status: 200,
+    headers: { "Content-Type": "application/xml" },
+  });
+}

--- a/app/api/feed/json/route.ts
+++ b/app/api/feed/json/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import { generateFeed } from "../../../../lib/generate-feed";
+
+export const revalidate = 86400;
+
+export async function GET() {
+  const feed = await generateFeed();
+
+  return new NextResponse(feed.json1(), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/app/api/feed/rss/route.ts
+++ b/app/api/feed/rss/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import { generateFeed } from "../../../../lib/generate-feed";
+
+export const revalidate = 86400;
+
+export async function GET() {
+  const feed = await generateFeed();
+
+  return new NextResponse(feed.rss2(), {
+    status: 200,
+    headers: { "Content-Type": "application/xml" },
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,6 +21,24 @@ export default function RootLayout({
           content="initial-scale=1, viewport-fit=cover, width=device-width"
         />
         <meta property="og:image" content="https://measured.co/social.png" />
+        <link
+          rel="alternate"
+          type="application/atom+xml"
+          href="/feed.atom"
+          title="Measured - Atom Feed"
+        ></link>
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          href="/feed.xml"
+          title="Measured - RSS Feed"
+        ></link>
+        <link
+          rel="alternate"
+          type="application/json"
+          href="/feed.json"
+          title="Measured - JSON Feed"
+        ></link>
         <link rel="canonical" href="https://measured.co" />
         <link rel="icon" href="favicon.png" type="image/png" />
         <link rel="icon" href="favicon.svg" type="image/svg+xml" />

--- a/components/Heading/index.tsx
+++ b/components/Heading/index.tsx
@@ -1,9 +1,23 @@
-import React from "react";
+import { ReactNode } from "react";
 
 import "./Heading.css";
 
-const Heading = ({ children, id, level, size, maxWidth, align }) => {
-  let Element = "div";
+const Heading = ({
+  align,
+  children,
+  id,
+  level,
+  maxWidth,
+  size,
+}: {
+  children: ReactNode;
+  align?: string;
+  id?: string;
+  level?: "1" | "2" | "3" | "4" | "5" | "6" | "";
+  maxWidth?: string;
+  size?: "1" | "2" | "3" | "4" | "5" | "6" | "display";
+}) => {
+  let Element: any = "div";
 
   if (level) {
     Element = `h${level}`;

--- a/components/Markdown/index.tsx
+++ b/components/Markdown/index.tsx
@@ -2,55 +2,22 @@
 
 import classNames from "classnames";
 import { useEffect, useState } from "react";
-import remarkGfm from "remark-gfm";
-import remarkRehype from "remark-rehype";
-import remarkParse from "remark-parse";
-import remarkSlug from "remark-slug";
-import rehypeHighlight from "rehype-highlight";
-import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
-import rehypeStringify from "rehype-stringify";
-import { unified } from "unified";
+
+import { processMarkdown, sanitizeDefault } from "../../lib/markdown";
 
 import "./hljs.css";
 import "./Markdown.css";
-
-const defaultOptions = {
-  ...defaultSchema,
-  attributes: {
-    ...defaultSchema.attributes,
-    code: [
-      ...(defaultSchema.attributes?.code || []),
-      ["className", /^language-./],
-    ],
-    span: [...(defaultSchema.attributes?.span || []), ["className", /^hljs-./]],
-  },
-  // Removing clobberPrefix is only safe if authors are trusted!
-  // https://github.com/rehypejs/rehype-sanitize#example-headings-dom-clobbering
-  clobberPrefix: "",
-};
-
-const processMarkdown = (markdown: string, options = defaultOptions) =>
-  unified()
-    .use(remarkParse)
-    .use(remarkGfm)
-    .use(remarkSlug)
-    .use(remarkRehype)
-    .use(rehypeHighlight)
-    // @ts-ignore
-    .use(rehypeSanitize, options)
-    .use(rehypeStringify)
-    .processSync(markdown);
 
 export const Markdown = ({
   align = "left",
   children,
   inline = false,
   measured = false,
-  options = defaultOptions,
+  sanitizeOptions = sanitizeDefault,
 }) => {
   let Element: any = "div";
   const [textProcessed, setTextProcessed] = useState(
-    processMarkdown(children, options)
+    processMarkdown(children.toString(), sanitizeOptions)
   );
 
   if (inline) {
@@ -58,7 +25,7 @@ export const Markdown = ({
   }
 
   useEffect(() => {
-    setTextProcessed(processMarkdown(children, options));
+    setTextProcessed(processMarkdown(children.toString(), sanitizeOptions));
   }, [children]);
 
   return (

--- a/components/Markdown/index.tsx
+++ b/components/Markdown/index.tsx
@@ -8,7 +8,7 @@ import { processMarkdown, sanitizeDefault } from "../../lib/markdown";
 import "./hljs.css";
 import "./Markdown.css";
 
-export const Markdown = ({
+const Markdown = ({
   align = "left",
   children,
   inline = false,
@@ -41,3 +41,5 @@ export const Markdown = ({
     />
   );
 };
+
+export default Markdown;

--- a/components/Markdown/index.tsx
+++ b/components/Markdown/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import classNames from "classnames";
-import { useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 
 import { processMarkdown, sanitizeDefault } from "../../lib/markdown";
 
@@ -14,6 +14,12 @@ const Markdown = ({
   inline = false,
   measured = false,
   sanitizeOptions = sanitizeDefault,
+}: {
+  align?: "left" | "center" | "right";
+  children: ReactNode;
+  inline?: boolean;
+  measured?: boolean;
+  sanitizeOptions?: any;
 }) => {
   let Element: any = "div";
   const [textProcessed, setTextProcessed] = useState(

--- a/components/Paragraph/index.tsx
+++ b/components/Paragraph/index.tsx
@@ -24,7 +24,7 @@ const Paragraph = ({
     >
       <Markdown
         inline
-        options={{
+        sanitizeOptions={{
           ...defaultSchema,
           tagNames: ["a", "b", "code", "del", "em", "strong", "sup"],
         }}

--- a/components/Paragraph/index.tsx
+++ b/components/Paragraph/index.tsx
@@ -1,8 +1,9 @@
 import { ReactNode } from "react";
 import { defaultSchema } from "rehype-sanitize";
 
+import { Markdown } from "..";
+
 import "./Paragraph.css";
-import { Markdown } from "../Markdown";
 
 const Paragraph = ({
   align,

--- a/components/Paragraph/index.tsx
+++ b/components/Paragraph/index.tsx
@@ -1,10 +1,20 @@
-import React from "react";
+import { ReactNode } from "react";
 import { defaultSchema } from "rehype-sanitize";
 
 import "./Paragraph.css";
 import { Markdown } from "../Markdown";
 
-const Paragraph = ({ children, size = null, maxWidth, align }) => {
+const Paragraph = ({
+  align,
+  children,
+  maxWidth,
+  size = "",
+}: {
+  align?: "left" | "center" | "right";
+  children: ReactNode;
+  maxWidth?: string;
+  size?: "" | "small" | "large";
+}) => {
   return (
     <p
       className={`msrd-Paragraph ${size ? `msrd-Paragraph--${size}` : ""} ${

--- a/components/index.js
+++ b/components/index.js
@@ -8,10 +8,10 @@ export { default as Header } from "./Header";
 export { default as Heading } from "./Heading";
 export { default as Hero } from "./Hero";
 export { default as Logos } from "./Logos";
+export { default as Markdown } from "./Markdown";
 export { default as Paragraph } from "./Paragraph";
 export { default as Profile } from "./Profile";
 export { default as ProfileDeck } from "./ProfileDeck";
-
 export { default as Section } from "./Section";
 export { default as Space } from "./Space";
 export { default as Technologies } from "./Technologies";

--- a/lib/generate-feed.ts
+++ b/lib/generate-feed.ts
@@ -1,0 +1,29 @@
+import { Feed } from "feed";
+
+import { getPosts } from "./get-posts";
+
+export const generateFeed = async () => {
+  const siteUrl = "https://measured.co";
+  const feed = new Feed({
+    copyright: `All rights reserved ${new Date().getFullYear()}, Measured Corporation Ltd`,
+    description: "A blog from Measured, the React and UI specialists.",
+    favicon: `${siteUrl}/favicon.ico`,
+    feedLinks: {
+      atom: `${siteUrl}/feed.atom`,
+      json: `${siteUrl}/feed.json`,
+      rss2: `${siteUrl}/feed.xml`,
+    },
+    id: siteUrl,
+    image: `${siteUrl}/social.png`,
+    language: "en-gb",
+    link: siteUrl,
+    title: "Measured",
+  });
+  const posts = await getPosts(siteUrl);
+
+  posts.forEach((post) => {
+    feed.addItem(post);
+  });
+
+  return feed;
+};

--- a/lib/get-posts.ts
+++ b/lib/get-posts.ts
@@ -1,0 +1,44 @@
+import { ComponentData, Data } from "@measured/puck";
+import { processMarkdown } from "./markdown";
+import { supabase } from "./supabase";
+
+export const getPosts = async (siteUrl: string) => {
+  const blogPath = "/blog";
+  const blogPageRes = await supabase
+    .from("puck")
+    .select("*")
+    .eq("path", blogPath)
+    .maybeSingle();
+  const blogPageData = blogPageRes?.data?.data as Data;
+  const archivePosts = blogPageData?.content?.filter(
+    (item: ComponentData) => item.type === "Archive"
+  )?.[0]?.props?.posts;
+  const posts = [];
+
+  for (const { slug } of archivePosts) {
+    const postPath = `${blogPath}/${slug}`;
+    const postPageRes = await supabase
+      .from("puck")
+      .select("*")
+      .eq("path", postPath)
+      .maybeSingle();
+    const postData = postPageRes?.data?.data as Data;
+    const post = postData?.content?.find(
+      (item: ComponentData) => item.type === "Post"
+    )?.props;
+    const postDescription = postData?.root?.props?.description;
+    const postLink = `${siteUrl}${postPath}`;
+
+    posts.push({
+      author: post.author,
+      content: processMarkdown(post.content)?.value,
+      date: new Date(post.date),
+      description: postDescription || "A blog post from Measured.",
+      id: postLink,
+      link: postLink,
+      title: post.title,
+    });
+  }
+
+  return posts.sort((a, b) => b.date - a.date);
+};

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,0 +1,38 @@
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import remarkParse from "remark-parse";
+import remarkSlug from "remark-slug";
+import rehypeHighlight from "rehype-highlight";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import rehypeStringify from "rehype-stringify";
+import { unified } from "unified";
+
+export const sanitizeDefault = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    code: [
+      ...(defaultSchema.attributes?.code || []),
+      ["className", /^language-./],
+    ],
+    span: [...(defaultSchema.attributes?.span || []), ["className", /^hljs-./]],
+  },
+  // Removing clobberPrefix is only safe if authors are trusted!
+  // https://github.com/rehypejs/rehype-sanitize#example-headings-dom-clobbering
+  clobberPrefix: "",
+};
+
+export const processMarkdown = (
+  markdown: string,
+  sanitizeOptions = sanitizeDefault
+) =>
+  unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkSlug)
+    .use(remarkRehype)
+    .use(rehypeHighlight)
+    // @ts-ignore
+    .use(rehypeSanitize, sanitizeOptions)
+    .use(rehypeStringify)
+    .processSync(markdown);

--- a/next.config.js
+++ b/next.config.js
@@ -8,4 +8,20 @@ module.exports = {
   },
   reactStrictMode: true,
   transpilePackages: ["ui"],
+  async rewrites() {
+    return [
+      {
+        destination: "/api/feed/atom",
+        source: "/feed.atom",
+      },
+      {
+        destination: "/api/feed/json",
+        source: "/feed.json",
+      },
+      {
+        destination: "/api/feed/rss",
+        source: "/feed.xml",
+      },
+    ];
+  },
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@supabase/auth-ui-shared": "^0.1.6",
     "@supabase/supabase-js": "^2.39.0",
     "classnames": "^2.3.2",
+    "feed": "^4.2.2",
     "next": "^14.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/puck.config.tsx
+++ b/puck.config.tsx
@@ -11,6 +11,7 @@ import {
   Heading,
   Hero,
   Logos,
+  Markdown,
   Paragraph,
   Profile,
   ProfileDeck,
@@ -20,7 +21,6 @@ import {
 } from "./components";
 
 import { logosMapping } from "./components/Logos";
-import { Markdown } from "./components/Markdown";
 
 type ProfileProps = {
   title: string;

--- a/puck.config.tsx
+++ b/puck.config.tsx
@@ -36,6 +36,14 @@ type ProfileProps = {
 };
 
 type Props = {
+  Archive: {
+    posts: {
+      author: string;
+      date: string;
+      slug: string;
+      title: string;
+    }[];
+  };
   Button: { href: string; label: string };
   Contact: {};
   Clients: {
@@ -58,6 +66,12 @@ type Props = {
     text: string;
     align: "left" | "center" | "right";
     measured: boolean;
+  };
+  Post: {
+    author: string;
+    content: string;
+    date: string;
+    title: string;
   };
   Paragraph: {
     size: "" | "small" | "large";
@@ -195,6 +209,60 @@ export const config: Config<Props, RootProps> = {
     },
   },
   components: {
+    Archive: {
+      fields: {
+        posts: {
+          type: "array",
+          arrayFields: {
+            title: {
+              type: "text",
+            },
+            slug: {
+              type: "text",
+            },
+            date: {
+              type: "text",
+            },
+            author: {
+              type: "text",
+            },
+          },
+          defaultItemProps: {
+            author: "Author",
+            date: new Date().toISOString().split("T")[0],
+            slug: "blog-post",
+            title: "Blog Post",
+          },
+          getItemSummary: (item) => item.title,
+        },
+      },
+      defaultProps: {
+        posts: [
+          {
+            author: "Author",
+            date: new Date().toISOString().split("T")[0],
+            slug: "blog-post",
+            title: "Blog Post",
+          },
+        ],
+      },
+      render: ({ posts }) => (
+        <Section>
+          <Cards>
+            {posts.map((post, idx) => (
+              <Card
+                artifact="🡒"
+                description={`${post.date} • ${post.author}`}
+                headingLevel={2}
+                link={`/blog/${post.slug}`}
+                title={post.title}
+                key={idx}
+              />
+            ))}
+          </Cards>
+        </Section>
+      ),
+    },
     Button: {
       fields: {
         href: { type: "text" },
@@ -500,6 +568,33 @@ export const config: Config<Props, RootProps> = {
           <Paragraph size={size} maxWidth={maxWidth} align={align}>
             {text}
           </Paragraph>
+        </Section>
+      ),
+    },
+    Post: {
+      fields: {
+        title: { type: "text" },
+        date: { type: "text" },
+        author: { type: "text" },
+        content: { type: "textarea" },
+      },
+      defaultProps: {
+        author: "Author",
+        content: "",
+        date: new Date().toISOString().split("T")[0],
+        title: "Title",
+      },
+      render: ({ author, content, date, title }) => (
+        <Section>
+          <Space size="07" />
+          <Heading level="1" maxWidth="15em" size="1">
+            {title}
+          </Heading>
+          <Space size="02" />
+          <Paragraph size="small">{`${date} • ${author}`}</Paragraph>
+          <Space size="06" />
+          <Markdown measured={true}>{content}</Markdown>
+          <Space size="12" />
         </Section>
       ),
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -968,6 +968,13 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+feed@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/feed/-/feed-4.2.2.tgz#865783ef6ed12579e2c44bbef3c9113bc4956a7e"
+  integrity sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==
+  dependencies:
+    xml-js "^1.6.11"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -2324,6 +2331,11 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sax@^1.2.4:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz#a5dbe77db3be05c9d1ee7785dbd3ea9de51593d0"
+  integrity sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
+
 scheduler@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
@@ -2779,6 +2791,13 @@ ws@^8.14.2:
   version "8.14.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f"
   integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
+
+xml-js@^1.6.11:
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"
+  integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
+  dependencies:
+    sax "^1.2.4"
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
⚠️ On merge I'll need to update the production blog pages to use the new components.

* [feed.atom](https://measuredco-site-git-feature-sc-2675-measured.vercel.app/feed.atom)
* [feed.json](https://measuredco-site-git-feature-sc-2675-measured.vercel.app/feed.json)
* [feed.xml](https://measuredco-site-git-feature-sc-2675-measured.vercel.app/feed.xml)

### Caveat

Currently we're (kinda) storing blog data in Puck twice — in the archive (`/blog`) and in the individual post pages. We likely want to store blog data outside of Puck, so we  can pull in from a single source via an external field. Could then refactor `generateFeed()` to use this external data too. But for the time being, this should work. I also made the editor situation a bit saner by adding `Archive` and `Post` abstractions, but we still need to update in both places.