### PR TITLE
feat: add twitter link

### DIFF
--- a/components/Footer/index.js
+++ b/components/Footer/index.js
@@ -78,6 +78,25 @@ const Footer = () => (
             </span>
           </a>
         </li>
+        <li>
+          <a href="https://twitter.com/hellomeasuredco" target="_blank">
+            <span className="msrd-Footer-textWithIcon">
+              <svg
+                aria-hidden="true"
+                className="msrd-Footer-linkIcon"
+                height="20"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m18.901 1.153h3.68l-8.04 9.19 9.459 12.503h-7.406l-5.8-7.584-6.638 7.584h-3.682l8.6-9.83-9.074-11.862h7.594l5.243 6.932zm-1.291 19.491h2.039l-13.163-17.404h-2.188z"
+                  fill="currentColor"
+                />
+              </svg>
+              Twitter
+            </span>
+          </a>
+        </li>
       </ul>
       <ul>
         <li>


### PR DESCRIPTION
[Add Twitter to Measured site footer](https://app.shortcut.com/msrd-site/story/2979/add-twitter-to-measured-site-footer)

This feels right

<img width="526" alt="Screenshot 2024-03-05 at 10 11 59" src="https://github.com/measuredco/measuredco-site/assets/98794/386ec672-652d-43dc-934b-393fd1eb1a1c">
